### PR TITLE
Add G3 CRL fixture test and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm hardhat compile
+
+      - run: pnpm hardhat test

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tsx": "^4.21.0",
     "typescript": "~5.8.0"
   },
+  "packageManager": "pnpm@9.12.3",
   "dependencies": {
     "@noble/curves": "^2.0.1",
     "@peculiar/x509": "^1.14.3",

--- a/test/fetch-crl.test.ts
+++ b/test/fetch-crl.test.ts
@@ -1,12 +1,23 @@
 import { expect } from "chai";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseCrl } from "../src/fetch-crl.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("CRL Parser", function () {
   this.timeout(60000);
 
   it("should parse a real G2 CRL from network", async function () {
     const url = "https://moica.nat.gov.tw/repository/MOICA/CRL2/complete.crl";
-    const response = await fetch(url);
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch {
+      this.skip();
+      return;
+    }
     if (!response.ok) {
       this.skip();
       return;
@@ -26,6 +37,31 @@ describe("CRL Parser", function () {
 
     console.log(
       `G2 CRL: ${result.serials.length} serials, CRL #${result.crlNumber}`
+    );
+  });
+
+  it("should parse G3 CRL from local fixture", function () {
+    const fixturePath = path.join(
+      __dirname,
+      "fixtures",
+      "MOICA-G3-complete.crl"
+    );
+    const derBuffer = fs.readFileSync(fixturePath);
+    const result = parseCrl(derBuffer.buffer);
+
+    expect(result.serials).to.be.an("array");
+    expect(result.serials.length).to.be.greaterThan(50000);
+    expect(result.crlNumber).to.not.equal("unknown");
+    expect(result.lastUpdate).to.be.instanceOf(Date);
+    expect(result.nextUpdate).to.be.instanceOf(Date);
+
+    // Serial numbers should be valid hex strings
+    for (const serial of result.serials.slice(0, 10)) {
+      expect(serial).to.match(/^[0-9a-f]+$/i);
+    }
+
+    console.log(
+      `G3 CRL: ${result.serials.length} serials, CRL #${result.crlNumber}`
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add local G3 CRL fixture test (`test/fixtures/MOICA-G3-complete.crl`) that always runs without network dependency
- Improve G2 network test to gracefully skip on fetch errors (not just non-200 responses)
- Add CI workflow (`.github/workflows/ci.yml`) that runs all tests on push/PR to main

## Test plan
- [x] G3 fixture test passes locally (103,453 serials parsed)
- [x] Full test suite passes (14/14: 3 Solidity + 11 Mocha)
- [ ] CI workflow triggers on this PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)