### PR TITLE
fix: resolve update-smt workflow failures

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -37,6 +37,28 @@ jobs:
           git add data/
           git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
           git push
+
+      - name: Upload snapshot
+        if: steps.fetch.outputs.changed == 'true'
+        run: |
+          gh release delete snapshot-latest --yes || true
+          assets=""
+          for gen in g2 g3; do
+            src="data/${gen}/tree-snapshot.json.gz"
+            if [ -f "$src" ]; then
+              dest="data/${gen}/${gen}-tree-snapshot.json.gz"
+              cp "$src" "$dest"
+              assets="$assets $dest"
+            fi
+          done
+          if [ -n "$assets" ]; then
+            gh release create snapshot-latest \
+              --title "SMT Snapshot" \
+              --notes "Auto-updated SMT snapshot $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              $assets
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post root on-chain
         if: steps.fetch.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Hardhat coverage reports
 /coverage
+
+# SMT snapshots (published as GitHub release assets)
+data/**/*.json.gz

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "fetch": "tsx src/fetch-crl.ts",
     "build:smt": "tsx src/build-smt.ts",
     "post:root": "tsx src/post-root.ts",
+    "serve": "tsx src/server/index.ts",
+    "dev": "tsx watch src/server/index.ts",
     "compile": "pnpm hardhat compile",
     "test": "pnpm hardhat test"
   },
@@ -27,9 +29,11 @@
   },
   "packageManager": "pnpm@9.12.3",
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@noble/curves": "^2.0.1",
     "@peculiar/x509": "^1.14.3",
     "@zk-kit/smt": "^1.0.2",
-    "circomlibjs": "^0.1.7"
+    "circomlibjs": "^0.1.7",
+    "hono": "^4.12.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.8)
       '@noble/curves':
         specifier: ^2.0.1
         version: 2.0.1
@@ -20,6 +23,9 @@ importers:
       circomlibjs:
         specifier: ^0.1.7
         version: 0.1.7
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^4.0.6
@@ -317,6 +323,12 @@ packages:
 
   '@ethersproject/wordlists@5.8.0':
     resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -928,6 +940,10 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
 
   immer@10.0.2:
     resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
@@ -1721,6 +1737,10 @@ snapshots:
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
+
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2544,6 +2564,8 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  hono@4.12.8: {}
 
   immer@10.0.2: {}
 

--- a/src/build-smt.ts
+++ b/src/build-smt.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { SMT } from "@zk-kit/smt";
 import { poseidonHash } from "./utils/poseidon.js";
+import { computeFileHash, saveSnapshot } from "./utils/tree-snapshot.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.resolve(__dirname, "../data");
@@ -62,11 +63,18 @@ async function main() {
     );
 
     const startTime = Date.now();
-    const { root, count } = buildSmtFromSerials(serials);
+    const { root, tree, count } = buildSmtFromSerials(serials);
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
     console.log(`${gen.toUpperCase()}: Root = 0x${root.toString(16)}`);
     console.log(`${gen.toUpperCase()}: ${count} entries in ${elapsed}s`);
+
+    // Save snapshot
+    const serialsHash = computeFileHash(serialsPath);
+    const snapshotPath = path.join(DATA_DIR, gen, "tree-snapshot.json.gz");
+    saveSnapshot(snapshotPath, tree, root, count, serialsHash);
+    const snapshotSize = (fs.statSync(snapshotPath).size / 1024 / 1024).toFixed(1);
+    console.log(`${gen.toUpperCase()}: Snapshot saved (${snapshotSize}MB)`);
 
     // Update root.json
     const rootPath = path.join(DATA_DIR, gen, "root.json");

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,19 @@
+import { serve } from "@hono/node-server";
+import { app } from "./routes.js";
+import { initAll } from "./tree-store.js";
+
+const PORT = parseInt(process.env.PORT ?? "3000", 10);
+
+async function main() {
+  console.log("Initializing SMT trees...");
+  await initAll();
+
+  serve({ fetch: app.fetch, port: PORT }, (info) => {
+    console.log(`\nServer listening on http://localhost:${info.port}`);
+  });
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+import {
+  VALID_ISSUER_IDS,
+  getProof,
+  getTreeState,
+  isLoading,
+  getAllStates,
+} from "./tree-store.js";
+
+const startedAt = Date.now();
+
+export const app = new Hono();
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
+
+/**
+ * Convert all BigInt values in a proof object to "0x" + hex strings.
+ */
+function serializeProof(proof: any): any {
+  if (typeof proof === "bigint") {
+    return "0x" + proof.toString(16);
+  }
+  if (Array.isArray(proof)) {
+    return proof.map(serializeProof);
+  }
+  if (proof !== null && typeof proof === "object") {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(proof)) {
+      result[key] = serializeProof(value);
+    }
+    return result;
+  }
+  return proof;
+}
+
+app.get("/proof/:issuerId/:sn", (c) => {
+  const { issuerId, sn } = c.req.param();
+
+  if (!VALID_ISSUER_IDS.includes(issuerId)) {
+    return c.json({ error: "Invalid issuerId" }, 400);
+  }
+
+  if (!HEX_RE.test(sn)) {
+    return c.json({ error: "Invalid serial number" }, 400);
+  }
+
+  if (isLoading(issuerId)) {
+    return c.json({ error: "Tree not yet loaded" }, 503);
+  }
+
+  const state = getTreeState(issuerId);
+  if (!state) {
+    return c.json({ error: "No data available" }, 404);
+  }
+
+  try {
+    const proof = getProof(issuerId, sn);
+    if (!proof) {
+      return c.json({ error: "No data available" }, 404);
+    }
+
+    const serialized = serializeProof(proof);
+    return c.json({
+      issuerId,
+      serialNumber: sn,
+      ...serialized,
+    });
+  } catch (err) {
+    console.error(`Error generating proof for ${issuerId}/${sn}:`, err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+app.get("/status", (c) => {
+  const uptimeMs = Date.now() - startedAt;
+  return c.json({
+    generations: getAllStates(),
+    uptimeSeconds: Math.floor(uptimeMs / 1000),
+  });
+});

--- a/src/server/tree-store.ts
+++ b/src/server/tree-store.ts
@@ -1,0 +1,228 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SMT } from "@zk-kit/smt";
+import { poseidonHash } from "../utils/poseidon.js";
+import {
+  computeFileHash,
+  saveSnapshot,
+  loadSnapshot,
+  downloadSnapshot,
+} from "../utils/tree-snapshot.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.resolve(__dirname, "../../data");
+
+const ISSUER_TO_DIR: Record<string, string> = {
+  "MOICA-G2": "g2",
+  "MOICA-G3": "g3",
+};
+
+export const VALID_ISSUER_IDS = Object.keys(ISSUER_TO_DIR);
+
+interface TreeState {
+  tree: SMT;
+  root: bigint;
+  count: number;
+  crlNumber: string | null;
+  loadedAt: string;
+}
+
+const trees = new Map<string, TreeState>();
+let loading = new Set<string>();
+
+function dataDir(issuerId: string): string {
+  return path.join(DATA_DIR, ISSUER_TO_DIR[issuerId]);
+}
+
+function serialsPath(issuerId: string): string {
+  return path.join(dataDir(issuerId), "revoked-serials.json");
+}
+
+function rootPath(issuerId: string): string {
+  return path.join(dataDir(issuerId), "root.json");
+}
+
+function snapshotPath(issuerId: string): string {
+  return path.join(dataDir(issuerId), "tree-snapshot.json.gz");
+}
+
+function generationId(issuerId: string): string {
+  return ISSUER_TO_DIR[issuerId];
+}
+
+/**
+ * Build SMT with async yields every 10K inserts to keep event loop responsive.
+ */
+async function buildSmtAsync(serials: string[]): Promise<{ tree: SMT; root: bigint }> {
+  const tree = new SMT(poseidonHash, true);
+  const BATCH = 10_000;
+
+  for (let i = 0; i < serials.length; i++) {
+    const key = BigInt("0x" + serials[i]);
+    tree.add(key, 1n);
+
+    if ((i + 1) % BATCH === 0) {
+      console.log(`  Inserted ${i + 1}/${serials.length}...`);
+      await new Promise<void>((r) => setImmediate(r));
+    }
+  }
+
+  return { tree, root: tree.root as bigint };
+}
+
+export async function loadGeneration(issuerId: string): Promise<void> {
+  const sp = serialsPath(issuerId);
+  if (!fs.existsSync(sp)) {
+    console.log(`${issuerId}: No serials file found, skipping.`);
+    return;
+  }
+
+  loading.add(issuerId);
+  const startTime = Date.now();
+
+  const serialsHash = computeFileHash(sp);
+  let tree: SMT;
+  let root: bigint;
+  let count: number;
+  let source: string;
+
+  // Try local snapshot
+  const snap = snapshotPath(issuerId);
+  const loaded = loadSnapshot(snap, serialsHash, poseidonHash);
+
+  if (loaded) {
+    tree = loaded.tree;
+    root = loaded.root;
+    count = loaded.count;
+    source = "local snapshot";
+  } else {
+    // Try downloading from GitHub release
+    const downloaded = await downloadSnapshot(generationId(issuerId), snap);
+    const fromRemote = downloaded
+      ? loadSnapshot(snap, serialsHash, poseidonHash)
+      : null;
+
+    if (fromRemote) {
+      tree = fromRemote.tree;
+      root = fromRemote.root;
+      count = fromRemote.count;
+      source = "downloaded snapshot";
+    } else {
+      // Fallback: build from scratch
+      const serials: string[] = JSON.parse(fs.readFileSync(sp, "utf-8"));
+      console.log(`${issuerId}: Building SMT from ${serials.length} serials...`);
+
+      const result = await buildSmtAsync(serials);
+      tree = result.tree;
+      root = result.root;
+      count = serials.length;
+      source = "built from scratch";
+
+      // Save snapshot for next time
+      saveSnapshot(snap, tree, root, count, serialsHash);
+      const snapshotSize = (fs.statSync(snap).size / 1024 / 1024).toFixed(1);
+      console.log(`${issuerId}: Snapshot saved (${snapshotSize}MB)`);
+    }
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  let crlNumber: string | null = null;
+  const rp = rootPath(issuerId);
+  if (fs.existsSync(rp)) {
+    try {
+      const rootData = JSON.parse(fs.readFileSync(rp, "utf-8"));
+      crlNumber = rootData.crlNumber ?? null;
+    } catch {
+      // ignore
+    }
+  }
+
+  trees.set(issuerId, {
+    tree,
+    root,
+    count,
+    crlNumber,
+    loadedAt: new Date().toISOString(),
+  });
+  loading.delete(issuerId);
+
+  console.log(`${issuerId}: Ready — ${count} entries, root=0x${root.toString(16).slice(0, 16)}…, ${elapsed}s (${source})`);
+}
+
+export function getTreeState(issuerId: string): TreeState | undefined {
+  return trees.get(issuerId);
+}
+
+export function isLoading(issuerId: string): boolean {
+  return loading.has(issuerId);
+}
+
+export function getProof(issuerId: string, serialHex: string) {
+  const state = trees.get(issuerId);
+  if (!state) return undefined;
+  const key = BigInt("0x" + serialHex);
+  return state.tree.createProof(key);
+}
+
+export function getAllStates(): Record<string, { loaded: boolean; count: number; root: string; crlNumber: string | null; loadedAt: string } | { loaded: false }> {
+  const result: Record<string, any> = {};
+  for (const issuerId of VALID_ISSUER_IDS) {
+    const state = trees.get(issuerId);
+    if (state) {
+      result[issuerId] = {
+        loaded: true,
+        count: state.count,
+        root: "0x" + state.root.toString(16),
+        crlNumber: state.crlNumber,
+        loadedAt: state.loadedAt,
+      };
+    } else {
+      result[issuerId] = { loaded: false };
+    }
+  }
+  return result;
+}
+
+export function startWatcher(): void {
+  const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  for (const issuerId of VALID_ISSUER_IDS) {
+    const sp = serialsPath(issuerId);
+    const dir = path.dirname(sp);
+    if (!fs.existsSync(dir)) continue;
+
+    fs.watch(dir, (eventType, filename) => {
+      if (filename !== "revoked-serials.json") return;
+
+      // Debounce 500ms
+      const existing = debounceTimers.get(issuerId);
+      if (existing) clearTimeout(existing);
+
+      debounceTimers.set(
+        issuerId,
+        setTimeout(async () => {
+          debounceTimers.delete(issuerId);
+          console.log(`${issuerId}: File change detected, rebuilding...`);
+          try {
+            // Delete stale snapshot so loadGeneration rebuilds from scratch
+            const snap = snapshotPath(issuerId);
+            if (fs.existsSync(snap)) fs.unlinkSync(snap);
+            await loadGeneration(issuerId);
+          } catch (err) {
+            console.error(`${issuerId}: Rebuild failed:`, err);
+          }
+        }, 500)
+      );
+    });
+
+    console.log(`${issuerId}: Watching ${dir} for changes`);
+  }
+}
+
+export async function initAll(): Promise<void> {
+  const promises = VALID_ISSUER_IDS.map((id) => loadGeneration(id));
+  await Promise.all(promises);
+  startWatcher();
+}

--- a/src/utils/tree-snapshot.ts
+++ b/src/utils/tree-snapshot.ts
@@ -1,0 +1,119 @@
+import * as fs from "node:fs";
+import * as crypto from "node:crypto";
+import { gzipSync, gunzipSync } from "node:zlib";
+import { SMT, type HashFunction } from "@zk-kit/smt";
+
+interface SnapshotData {
+  serialsHash: string;
+  root: string;
+  count: number;
+  nodes: [string, string[]][];
+}
+
+/**
+ * Compute SHA-256 hex digest of a file's contents.
+ */
+export function computeFileHash(filePath: string): string {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Serialize an SMT to a gzipped JSON snapshot file.
+ */
+export function saveSnapshot(
+  snapshotPath: string,
+  tree: SMT,
+  root: bigint,
+  count: number,
+  serialsHash: string,
+): void {
+  const nodesMap = (tree as any).nodes as Map<bigint, bigint[]>;
+  const nodes: [string, string[]][] = [];
+
+  for (const [key, value] of nodesMap) {
+    nodes.push([
+      "0x" + BigInt(key).toString(16),
+      value.map((v: bigint) => "0x" + BigInt(v).toString(16)),
+    ]);
+  }
+
+  const data: SnapshotData = {
+    serialsHash,
+    root: "0x" + root.toString(16),
+    count,
+    nodes,
+  };
+
+  const json = JSON.stringify(data);
+  const compressed = gzipSync(Buffer.from(json));
+  fs.writeFileSync(snapshotPath, compressed);
+}
+
+/**
+ * Load an SMT from a gzipped JSON snapshot file.
+ * Returns null if the file doesn't exist, is corrupt, or the hash doesn't match.
+ */
+export function loadSnapshot(
+  snapshotPath: string,
+  expectedHash: string,
+  hashFn: HashFunction,
+): { tree: SMT; root: bigint; count: number } | null {
+  if (!fs.existsSync(snapshotPath)) return null;
+
+  try {
+    const compressed = fs.readFileSync(snapshotPath);
+    const json = gunzipSync(compressed).toString("utf-8");
+    const data: SnapshotData = JSON.parse(json);
+
+    if (data.serialsHash !== expectedHash) {
+      console.log("Snapshot hash mismatch, will rebuild.");
+      return null;
+    }
+
+    const tree = new SMT(hashFn, true);
+    const nodesMap = (tree as any).nodes as Map<bigint, bigint[]>;
+
+    for (const [key, value] of data.nodes) {
+      nodesMap.set(BigInt(key), value.map((v: string) => BigInt(v)));
+    }
+
+    const root = BigInt(data.root);
+    (tree as any).root = root;
+
+    return { tree, root, count: data.count };
+  } catch (err) {
+    console.error("Failed to load snapshot:", err);
+    return null;
+  }
+}
+
+const GITHUB_REPO = "moven0831/moica-revocation-smt";
+
+/**
+ * Download a snapshot from the GitHub release "snapshot-latest".
+ * Returns true on success.
+ */
+export async function downloadSnapshot(
+  generation: string,
+  destPath: string,
+): Promise<boolean> {
+  const url = `https://github.com/${GITHUB_REPO}/releases/download/snapshot-latest/${generation}-tree-snapshot.json.gz`;
+
+  try {
+    console.log(`Downloading snapshot from ${url}...`);
+    const response = await fetch(url, { redirect: "follow" });
+    if (!response.ok) {
+      console.log(`Snapshot download failed: ${response.status}`);
+      return false;
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(destPath, buffer);
+    console.log(`Snapshot downloaded (${(buffer.length / 1024 / 1024).toFixed(1)}MB)`);
+    return true;
+  } catch (err) {
+    console.log(`Snapshot download error: ${err}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Remove explicit `version: 9` from `pnpm/action-setup@v4` — the action now auto-reads from `package.json`'s `packageManager` field, and the duplicate spec causes a hard error
- Add `permissions: contents: write` to the update job — required for `git push` and `gh release create/delete`
- Add tree snapshot saving to `build-smt` and snapshot upload step to CI workflow
- Add Hono-based server for serving SMT data (`src/server/`)
- Gitignore gzipped snapshot files (published as GitHub release assets)

## Test plan
- [ ] Trigger `workflow_dispatch` manually: `gh workflow run update-smt.yml`
- [ ] Confirm pnpm setup step passes without version conflict
- [ ] Confirm `git push` and `gh release` steps succeed (no 403)
- [ ] Verify snapshot files are uploaded as release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)