### PR TITLE
feat: add length bound to serial number input

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -40,7 +40,7 @@ app.get("/proof/:issuerId/:sn", (c) => {
     return c.json({ error: "Invalid issuerId" }, 400);
   }
 
-  if (!HEX_RE.test(sn)) {
+  if (!HEX_RE.test(sn) || sn.length > 64) {
     return c.json({ error: "Invalid serial number" }, 400);
   }
 


### PR DESCRIPTION
## Summary
- Add max-length check (64 hex chars / 256 bits) to serial number input validation in the proof endpoint
- Rejects oversized serial numbers with a 400 error before any tree lookup

## Test plan
- [ ] Verify requests with serial numbers <= 64 hex chars still work
- [ ] Verify requests with serial numbers > 64 hex chars return 400

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)