### PR TITLE
feat: make GitHub repo URL configurable

### DIFF
--- a/src/utils/tree-snapshot.ts
+++ b/src/utils/tree-snapshot.ts
@@ -88,7 +88,7 @@ export function loadSnapshot(
   }
 }
 
-const GITHUB_REPO = "moven0831/moica-revocation-smt";
+const GITHUB_REPO = process.env.GITHUB_REPO ?? "moven0831/moica-revocation-smt";
 
 /**
  * Download a snapshot from the GitHub release "snapshot-latest".


### PR DESCRIPTION
## Summary
- Replace hardcoded `GITHUB_REPO` constant with `process.env.GITHUB_REPO ?? "moven0831/moica-revocation-smt"` fallback
- Allows forks and alternative deployments to configure snapshot download URL

## Test plan
- [x] All existing tests pass
- [ ] Verify `GITHUB_REPO=owner/repo` env var overrides the default

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)