### PR TITLE
fix: verify tree integrity after loading snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@hono/node-server": "^1.19.11",
     "@noble/curves": "^2.0.1",
     "@peculiar/x509": "^1.14.3",
-    "@zk-kit/smt": "^1.0.2",
+    "@zk-kit/smt": "1.0.2",
     "circomlibjs": "^0.1.7",
     "hono": "^4.12.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^1.14.3
         version: 1.14.3
       '@zk-kit/smt':
-        specifier: ^1.0.2
+        specifier: 1.0.2
         version: 1.0.2
       circomlibjs:
         specifier: ^0.1.7

--- a/src/utils/tree-snapshot.ts
+++ b/src/utils/tree-snapshot.ts
@@ -81,6 +81,21 @@ export function loadSnapshot(
     const root = BigInt(data.root);
     (tree as any).root = root;
 
+    // Verify integrity by checking a sample entry
+    if (data.nodes.length > 0) {
+      const sampleKey = data.nodes[0][0];
+      try {
+        const proof = tree.createProof(BigInt(sampleKey));
+        if (!tree.verifyProof(proof)) {
+          console.error("Snapshot integrity check failed: proof verification failed");
+          return null;
+        }
+      } catch (err) {
+        console.error("Snapshot integrity check failed:", err);
+        return null;
+      }
+    }
+
     return { tree, root, count: data.count };
   } catch (err) {
     console.error("Failed to load snapshot:", err);


### PR DESCRIPTION
## Summary
- After reconstructing an SMT from a snapshot, verify integrity by generating and checking a proof for a sample key. Returns `null` if verification fails, triggering a full rebuild.
- Pins `@zk-kit/smt` to exact version `1.0.2` (removes `^`) to prevent unexpected breaking changes.

## Test plan
- [x] All existing tests pass (14 passing)
- [ ] Verify snapshot load still works in CI (cron workflow)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)