### PR TITLE
chore: deprecate update-smt workflow

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -1,11 +1,16 @@
-name: Update SMT
+name: "[DEPRECATED] Update SMT"
+
+# DEPRECATED: This workflow has been moved to https://github.com/moven0831/moica-revocation-smt
+# Keeping this file to prevent GitHub from re-enabling a deleted scheduled workflow.
 on:
-  schedule:
-    - cron: '0 */6 * * *'
   workflow_dispatch: {}
+
+# All jobs are disabled — the pipeline now runs in the new repository.
+
 
 jobs:
   update:
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -64,13 +64,7 @@ pnpm hardhat ignition deploy ignition/modules/SMTRootStorage.ts --parameters '{"
 
 ## CI/CD
 
-The `update-smt.yml` workflow runs every 6 hours:
-1. Fetch CRL from MOICA
-2. Compare CRL number — skip if unchanged
-3. Build SMT, commit `data/` to repo
-4. Post root to on-chain contract
-
-**Required secrets**: `RELAYER_PRIVATE_KEY`, `RPC_URL`, `CONTRACT_ADDRESS`
+> **Note:** The SMT update pipeline has moved to [moven0831/moica-revocation-smt](https://github.com/moven0831/moica-revocation-smt). The `update-smt.yml` workflow in this repo is deprecated and disabled.
 
 ## Generating Non-Membership Proofs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # moica-revocation-smt
 
-Converts MOICA Certificate Revocation Lists (CRL) into a Sparse Merkle Tree (SMT) for ZK non-membership proofs. The pipeline fetches Taiwan's MOICA CRL, parses revoked certificate serials, builds an SMT using Poseidon hash over the secq256r1 scalar field, and posts the root on-chain. A GitHub Action runs this every 6 hours.
+> **Note:** This project has moved to [moven0831/moica-revocation-smt](https://github.com/moven0831/moica-revocation-smt). The SMT update pipeline in this repo is deprecated and disabled.
+
+Converts MOICA Certificate Revocation Lists (CRL) into a Sparse Merkle Tree (SMT) for ZK non-membership proofs. The pipeline fetches Taiwan's MOICA CRL, parses revoked certificate serials, builds an SMT using Poseidon hash over the secq256r1 scalar field, and posts the root on-chain.
 
 ## Architecture
 
@@ -61,10 +63,6 @@ Deploy with Hardhat Ignition:
 ```bash
 pnpm hardhat ignition deploy ignition/modules/SMTRootStorage.ts --parameters '{"relayer":"0x..."}'
 ```
-
-## CI/CD
-
-> **Note:** The SMT update pipeline has moved to [moven0831/moica-revocation-smt](https://github.com/moven0831/moica-revocation-smt). The `update-smt.yml` workflow in this repo is deprecated and disabled.
 
 ## Generating Non-Membership Proofs
 


### PR DESCRIPTION
## Summary
- Deprecate the `update-smt` scheduled workflow since the pipeline has moved to [moven0831/moica-revocation-smt](https://github.com/moven0831/moica-revocation-smt)
- Remove the cron schedule trigger and add `if: false` to disable the job
- Keep the file to prevent GitHub from re-enabling a cached schedule

## Test plan
- [ ] Verify the workflow no longer appears as scheduled in the Actions tab
- [ ] Confirm manual dispatch shows the job as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)